### PR TITLE
Add missing `public` base specifier and use C++17 standard

### DIFF
--- a/OpenGL.vcxproj
+++ b/OpenGL.vcxproj
@@ -105,6 +105,9 @@
       <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>false</ConformanceMode>
       <AdditionalIncludeDirectories>src; </AdditionalIncludeDirectories>
+      <LanguageStandard>stdcpp17</LanguageStandard>
+      <EnforceTypeConversionRules>
+      </EnforceTypeConversionRules>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/src/tests/Test.h
+++ b/src/tests/Test.h
@@ -31,11 +31,11 @@ namespace test
 		{
 			std::cout << "Registering test " << name << std::endl;
 
-			m_Tests.push_back(std::make_pair(name, [] { return (Test*) new T(); }));
+			m_Tests.push_back({name, [] { return new T(); }});
 		}
 
 	private:
 		Test*& m_CurrentTest;
-		std::vector < std::pair<std::string, std::function<Test* ()>>> m_Tests;
+		std::vector<std::pair<std::string, std::function<Test*()>>> m_Tests;
 	};
 }

--- a/src/tests/TestClearColor.h
+++ b/src/tests/TestClearColor.h
@@ -4,7 +4,7 @@
 
 namespace test
 {
-	class TestClearColor : Test
+	class TestClearColor : public Test
 	{
 	public:
 		TestClearColor();


### PR DESCRIPTION
- Add missing `public` base specifier to allow implicit casting from `TestClearColor*` to `Test*`
- Use C++17 standard